### PR TITLE
Use CC64 threshold for sustain release

### DIFF
--- a/midi_sustain_filter.jsfx
+++ b/midi_sustain_filter.jsfx
@@ -1,17 +1,17 @@
 desc: MIDI sustain filter - hold notes while CC64 is active
 author: tomaszpio
-version: 1.2.1
+version: 1.2.2
 about:
-  A minimal sustain-style JSFX. When sustain (MIDI CC64) is above 0, it
+  A minimal sustain-style JSFX. When sustain (MIDI CC64) is >= 64, it
   remembers any Note On messages (and any later Note Offs) and holds those
-  notes. When sustain returns to 0, Note Off is sent for every remembered
+  notes. When sustain falls below 64, Note Off is sent for every remembered
   note so all held notes are released.
 
   HOW IT WORKS:
   - Note On messages always pass through immediately.
-  - If sustain (CC64) is > 0, Note On and Note Off are remembered (held)
+  - If sustain (CC64) is >= 64, Note On and Note Off are remembered (held)
     instead of being released normally.
-  - When sustain returns to 0, all held notes receive a Note Off.
+  - When sustain falls below 64, all held notes receive a Note Off.
   - Non-note messages and CC64 are forwarded unchanged.
 
 in_pin:none
@@ -37,8 +37,8 @@ while (midirecv(ts, msg, msg23)) (
   status == $xb0 && d1 == 64 ? (
     midisend(ts, msg, msg23);
 
-    // CC64 is "on" for values > 0, "off" otherwise
-    sustain_on = d2 > 0;
+    // CC64 is "on" for values >= 64, "off" otherwise
+    sustain_on = d2 >= 64;
 
     // When pedal transitions to released, flush all held notes
     (pedal_down && !sustain_on) ? (

--- a/midi_sustain_hold.jsfx
+++ b/midi_sustain_hold.jsfx
@@ -1,17 +1,18 @@
 desc: MIDI sustain hold - hold multiple notes while sustain pedal (CC64) is pressed
 author: tomaszpio
-version: 1.1.0
+version: 1.1.1
 about:
   This JSFX plugin implements a sustain-hold behaviour similar to an
-  instrument sustain pedal: when sustain (MIDI CC64) is held (value > 0),
+  instrument sustain pedal: when sustain (MIDI CC64) is held (value >= 64),
   incoming Note Off messages are intercepted and the notes are kept (held).
-  When the pedal is released (CC64 = 0), all previously held notes are
+  When the pedal is released (CC64 < 64), all previously held notes are
   released (Note Off messages are sent).
 
   FEATURES:
   - Works in Omni mode (Channel = 0) or on a single MIDI channel (1..16).
   - Holds any number of notes simultaneously while sustain is pressed.
   - CC64 messages and all non-note messages are forwarded unchanged.
+  - Sustain engages at values >= 64 and releases below 64 (per MIDI spec).
 
   USAGE:
   - Put this JSFX between your MIDI input and instrument in REAPER so it
@@ -59,8 +60,10 @@ while (midirecv(ts, msg, msg23)) (
     // Forward the CC message unchanged
     midisend(ts, msg, msg23);
 
+    sustain_on = d2 >= 64;
+
     // Pedal release: flush held notes
-    (d2 == 0 && pedal_down) ? (
+    (pedal_down && !sustain_on) ? (
       i = 0;
       while (i < 128) (
         held[i] ? (
@@ -72,7 +75,7 @@ while (midirecv(ts, msg, msg23)) (
     );
 
     // Update pedal state
-    pedal_down = d2 > 0;
+    pedal_down = sustain_on;
   ) : (
     // Note processing
     is_note && in_chan ? (

--- a/tests/test_midi_sustain_filter.py
+++ b/tests/test_midi_sustain_filter.py
@@ -29,7 +29,7 @@ class MidiSustainFilterSimulator:
             # Sustain pedal
             if msg_type == CC and d1 == SUSTAIN_CC:
                 outputs.append((status, d1, d2))
-                sustain_on = d2 > 0
+                sustain_on = d2 >= 64
                 if self.pedal_down and not sustain_on:
                     for note, held in enumerate(self.held):
                         if held:
@@ -84,14 +84,14 @@ def test_note_offs_flushed_when_pedal_value_hits_zero():
     ]
 
 
-def test_pedal_release_occurs_only_at_zero():
+def test_pedal_release_occurs_when_value_drops_below_threshold():
     sim = MidiSustainFilterSimulator()
     events = [
         (NOTE_ON, 62, 90),
         (CC, SUSTAIN_CC, 90),
         (NOTE_OFF, 62, 0),
-        (CC, SUSTAIN_CC, 50),  # still down (no flush)
-        (CC, SUSTAIN_CC, 0),   # pedal up triggers release
+        (CC, SUSTAIN_CC, 50),  # below threshold triggers release
+        (CC, SUSTAIN_CC, 0),   # stays released
     ]
 
     output = sim.process(events)
@@ -100,8 +100,8 @@ def test_pedal_release_occurs_only_at_zero():
         "90:62:90",
         "B0:64:90",
         "B0:64:50",
-        "B0:64:0",
         "80:62:0",
+        "B0:64:0",
     ]
 
 


### PR DESCRIPTION
## Summary
- interpret sustain pedal (CC64) as engaged only at values >= 64 in both sustain JSFX scripts
- document the MIDI-spec threshold behaviour and update sustain simulators/tests accordingly
- ensure held notes flush when CC64 drops below the threshold

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695452db7608832f99bdb97791737033)