### PR TITLE
Make sustain release only at CC64 zero

### DIFF
--- a/midi_sustain_filter.jsfx
+++ b/midi_sustain_filter.jsfx
@@ -1,17 +1,17 @@
 desc: MIDI sustain filter - hold notes while CC64 is active
 author: tomaszpio
-version: 1.2.2
+version: 1.3.0
 about:
-  A minimal sustain-style JSFX. When sustain (MIDI CC64) is >= 64, it
+  A minimal sustain-style JSFX. When sustain (MIDI CC64) is > 0, it
   remembers any Note On messages (and any later Note Offs) and holds those
-  notes. When sustain falls below 64, Note Off is sent for every remembered
+  notes. When sustain returns to 0, Note Off is sent for every remembered
   note so all held notes are released.
 
   HOW IT WORKS:
   - Note On messages always pass through immediately.
-  - If sustain (CC64) is >= 64, Note On and Note Off are remembered (held)
+  - If sustain (CC64) is > 0, Note On and Note Off are remembered (held)
     instead of being released normally.
-  - When sustain falls below 64, all held notes receive a Note Off.
+  - When sustain returns to 0, all held notes receive a Note Off.
   - Non-note messages and CC64 are forwarded unchanged.
 
 in_pin:none
@@ -37,8 +37,8 @@ while (midirecv(ts, msg, msg23)) (
   status == $xb0 && d1 == 64 ? (
     midisend(ts, msg, msg23);
 
-    // CC64 is "on" for values >= 64, "off" otherwise
-    sustain_on = d2 >= 64;
+    // CC64 is "on" for values > 0, "off" only at 0
+    sustain_on = d2 > 0;
 
     // When pedal transitions to released, flush all held notes
     (pedal_down && !sustain_on) ? (

--- a/midi_sustain_hold.jsfx
+++ b/midi_sustain_hold.jsfx
@@ -1,18 +1,18 @@
 desc: MIDI sustain hold - hold multiple notes while sustain pedal (CC64) is pressed
 author: tomaszpio
-version: 1.1.1
+version: 1.2.0
 about:
   This JSFX plugin implements a sustain-hold behaviour similar to an
-  instrument sustain pedal: when sustain (MIDI CC64) is held (value >= 64),
+  instrument sustain pedal: when sustain (MIDI CC64) is held (value > 0),
   incoming Note Off messages are intercepted and the notes are kept (held).
-  When the pedal is released (CC64 < 64), all previously held notes are
+  When the pedal is released (CC64 returns to 0), all previously held notes are
   released (Note Off messages are sent).
 
   FEATURES:
   - Works in Omni mode (Channel = 0) or on a single MIDI channel (1..16).
   - Holds any number of notes simultaneously while sustain is pressed.
   - CC64 messages and all non-note messages are forwarded unchanged.
-  - Sustain engages at values >= 64 and releases below 64 (per MIDI spec).
+  - Sustain engages at values > 0 and releases when it returns to 0.
 
   USAGE:
   - Put this JSFX between your MIDI input and instrument in REAPER so it
@@ -60,7 +60,7 @@ while (midirecv(ts, msg, msg23)) (
     // Forward the CC message unchanged
     midisend(ts, msg, msg23);
 
-    sustain_on = d2 >= 64;
+    sustain_on = d2 > 0;
 
     // Pedal release: flush held notes
     (pedal_down && !sustain_on) ? (

--- a/tests/test_midi_sustain_filter.py
+++ b/tests/test_midi_sustain_filter.py
@@ -29,7 +29,7 @@ class MidiSustainFilterSimulator:
             # Sustain pedal
             if msg_type == CC and d1 == SUSTAIN_CC:
                 outputs.append((status, d1, d2))
-                sustain_on = d2 >= 64
+                sustain_on = d2 > 0
                 if self.pedal_down and not sustain_on:
                     for note, held in enumerate(self.held):
                         if held:
@@ -84,14 +84,14 @@ def test_note_offs_flushed_when_pedal_value_hits_zero():
     ]
 
 
-def test_pedal_release_occurs_when_value_drops_below_threshold():
+def test_pedal_release_occurs_only_at_zero():
     sim = MidiSustainFilterSimulator()
     events = [
         (NOTE_ON, 62, 90),
         (CC, SUSTAIN_CC, 90),
         (NOTE_OFF, 62, 0),
-        (CC, SUSTAIN_CC, 50),  # below threshold triggers release
-        (CC, SUSTAIN_CC, 0),   # stays released
+        (CC, SUSTAIN_CC, 50),  # still held because sustain > 0
+        (CC, SUSTAIN_CC, 0),   # release when sustain hits 0
     ]
 
     output = sim.process(events)
@@ -100,8 +100,8 @@ def test_pedal_release_occurs_when_value_drops_below_threshold():
         "90:62:90",
         "B0:64:90",
         "B0:64:50",
-        "80:62:0",
         "B0:64:0",
+        "80:62:0",
     ]
 
 

--- a/tests/test_midi_sustain_hold.py
+++ b/tests/test_midi_sustain_hold.py
@@ -32,7 +32,7 @@ class MidiSustainHoldSimulator:
 
             if msg_type == CC and d1 == SUSTAIN_CC:
                 outputs.append((status, d1, d2))
-                sustain_on = d2 >= 64
+                sustain_on = d2 > 0
                 if self.pedal_down and not sustain_on:
                     for note, held in enumerate(self.held):
                         if held:
@@ -105,13 +105,14 @@ def test_multiple_notes_released_on_pedal_up():
     ]
 
 
-def test_pedal_release_when_value_drops_below_threshold():
+def test_pedal_release_only_at_zero():
     sim = MidiSustainHoldSimulator()
     events = [
         (NOTE_ON, 50, 97),
         (CC, SUSTAIN_CC, 100),  # sustain engaged
         (NOTE_OFF, 50, 0),      # should be held
-        (CC, SUSTAIN_CC, 60),   # below 64 releases held notes
+        (CC, SUSTAIN_CC, 60),   # still held because sustain > 0
+        (CC, SUSTAIN_CC, 0),    # zero releases held notes
     ]
 
     output = sim.process(events)
@@ -120,5 +121,6 @@ def test_pedal_release_when_value_drops_below_threshold():
         "90:50:97",
         "B0:64:100",
         "B0:64:60",
+        "B0:64:0",
         "80:50:0",
     ]


### PR DESCRIPTION
## Summary
- change sustain detection in both JSFX plugins to treat any CC64 value above zero as held and release only when it returns to zero
- update plugin metadata/documentation to reflect the new sustain threshold
- adjust simulators and tests to expect note-off flushing solely at CC64 value 0

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69545531f310832fbf0634721d0d8b13)